### PR TITLE
Running subscriber in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM openjdk:8-slim
 
-ARG FLEET_VERSION=compiler-fleet-1.0-SNAPSHOT
+ARG FLEET_VERSION=papeeria-compiler-fleet-1.0-SNAPSHOT.tar
 
 ADD ./build/distributions/${FLEET_VERSION}.tar  .
 
 WORKDIR ./${FLEET_VERSION}/bin/
 
-ENTRYPOINT ["./compiler-fleet"]
+ENTRYPOINT ["./papeeria-compiler-fleet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim
 
-ARG FLEET_VERSION=papeeria-compiler-fleet-1.0-SNAPSHOT.tar
+ARG FLEET_VERSION=papeeria-compiler-fleet-1.0-SNAPSHOT
 
 ADD ./build/distributions/${FLEET_VERSION}.tar  .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:8-slim
+
+ARG FLEET_VERSION=compiler-fleet-1.0-SNAPSHOT
+
+ADD ./build/distributions/${FLEET_VERSION}.zip  ./${FLEET_VERSION}.zip
+
+RUN unzip -n ${FLEET_VERSION}.zip
+
+WORKDIR ./${FLEET_VERSION}/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM openjdk:8-slim
 
 ARG FLEET_VERSION=papeeria-compiler-fleet-1.0-SNAPSHOT
 
-ADD ./build/distributions/${FLEET_VERSION}.tar  .
+ADD /build/distributions/${FLEET_VERSION}.tar  .
 
-WORKDIR ./${FLEET_VERSION}/bin/
+WORKDIR /${FLEET_VERSION}/bin/
 
 ENTRYPOINT ["./papeeria-compiler-fleet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM openjdk:8-slim
 
 ARG FLEET_VERSION=compiler-fleet-1.0-SNAPSHOT
 
-ADD ./build/distributions/${FLEET_VERSION}.zip  ./${FLEET_VERSION}.zip
-
-RUN unzip -n ${FLEET_VERSION}.zip
+ADD ./build/distributions/${FLEET_VERSION}.tar  .
 
 WORKDIR ./${FLEET_VERSION}/bin/
+
+ENTRYPOINT ["./compiler-fleet"]

--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,19 @@ buildscript {
 
 apply plugin: 'java'
 apply plugin: 'kotlin'
+apply plugin: 'distribution'
 apply plugin: 'application'
 apply plugin: 'com.google.protobuf'
 
 repositories {
     mavenCentral()
     jcenter()
+}
+
+distributions {
+    main {
+        baseName = 'papeeria-compiler-fleet'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Maybe, it's good to set an entrypoint as ./compiler-fleet, but I'm little bit confused about passing java arguments through docker.

`docker run containerName --sub=subName -tasks-dir=dirName`
doesn't work with entrypoint

`docker run containerName ./compiler-fleet --sub=subName --tasks-dir=dirName`
worked for me without entrypoint