### PR TITLE
Publisher failures processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     compile 'com.google.protobuf:protobuf-java:3.5.+'
     compile 'commons-io:commons-io:2.+'
     compile 'com.google.guava:guava:23.+'
+    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'ch.qos.logback:logback-classic:1.3.+'
+    compile 'ch.qos.logback:logback-core:1.3.+'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     //uncomment when we start doing grpc requests

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
@@ -24,10 +24,10 @@ import com.google.pubsub.v1.PubsubMessage
 import com.google.pubsub.v1.TopicName
 import org.slf4j.LoggerFactory
 
-fun getResultData(taskId: String, statusCode: Int, result: String): ByteString {
+fun getResultData(taskId: String, statusCode: StatusCode, result: String): ByteString {
     return CompilerFleet.CompilerFleetResult.newBuilder()
             .setTaskId(taskId)
-            .setStatusCode(statusCode)
+            .setStatusCode(statusCode.ordinal)
             .setResultBytes(ByteString.copyFrom(result.toByteArray()))
             .build()
             .toByteString()

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
@@ -56,7 +56,7 @@ class Publisher(private val topicName: String) {
         ApiFutures.addCallback(future, object : ApiFutureCallback<String> {
 
             override fun onFailure(throwable: Throwable) {
-                LOGGER.info(throwable.toString())
+                LOGGER.error("Failed on publish with message:", throwable.message, throwable)
                 onFailureCallback()
             }
 

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
@@ -22,7 +22,7 @@ import com.google.cloud.pubsub.v1.Publisher
 import com.google.protobuf.ByteString
 import com.google.pubsub.v1.PubsubMessage
 import com.google.pubsub.v1.TopicName
-import java.util.logging.Logger
+import org.slf4j.LoggerFactory
 
 fun getResultData(taskId: String, statusCode: Int, result: String): ByteString {
     return CompilerFleet.CompilerFleetResult.newBuilder()
@@ -33,7 +33,7 @@ fun getResultData(taskId: String, statusCode: Int, result: String): ByteString {
             .toByteString()
 }
 
-val logger = Logger.getLogger(Publisher::class.java.getName())
+private val logger = LoggerFactory.getLogger("Publisher")
 
 class Publisher(private val topicName: String) {
     private val pubsubPublisher: Publisher

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
@@ -56,7 +56,7 @@ class Publisher(private val topicName: String) {
         ApiFutures.addCallback(future, object : ApiFutureCallback<String> {
 
             override fun onFailure(throwable: Throwable) {
-                LOGGER.error("Failed on publish with message:", throwable.message, throwable)
+                LOGGER.error("Failed on publish with message: {}", throwable.message, throwable)
                 onFailureCallback()
             }
 

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
@@ -33,7 +33,7 @@ fun getResultData(taskId: String, statusCode: Int, result: String): ByteString {
             .toByteString()
 }
 
-private val logger = LoggerFactory.getLogger("Publisher")
+private val LOGGER = LoggerFactory.getLogger("Publisher")
 
 class Publisher(private val topicName: String) {
     private val pubsubPublisher: Publisher
@@ -56,12 +56,12 @@ class Publisher(private val topicName: String) {
         ApiFutures.addCallback(future, object : ApiFutureCallback<String> {
 
             override fun onFailure(throwable: Throwable) {
-                logger.info(throwable.toString())
+                LOGGER.info(throwable.toString())
                 onFailureCallback()
             }
 
             override fun onSuccess(messageId: String) {
-                logger.info("successful published $messageId")
+                LOGGER.info("successful published $messageId")
             }
         })
     }

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Publisher.kt
@@ -24,11 +24,11 @@ import com.google.pubsub.v1.PubsubMessage
 import com.google.pubsub.v1.TopicName
 import org.slf4j.LoggerFactory
 
-fun getResultData(taskId: String, statusCode: StatusCode, result: String): ByteString {
+fun getResultData(taskId: String, statusCode: StatusCode, resultBytes: ByteArray): ByteString {
     return CompilerFleet.CompilerFleetResult.newBuilder()
             .setTaskId(taskId)
             .setStatusCode(statusCode.ordinal)
-            .setResultBytes(ByteString.copyFrom(result.toByteArray()))
+            .setResultBytes(ByteString.copyFrom(resultBytes))
             .build()
             .toByteString()
 }

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -49,6 +49,12 @@ class SubscriberArgs(parser: ArgParser) {
     )
 }
 
+enum class StatusCode(private val code: Int) {
+    SUCCESS(0), FAILURE(1);
+
+    fun getCode(): Int = code
+}
+
 private val PROJECT_ID = ServiceOptions.getDefaultProjectId()
 
 abstract class CompilerFleetMessageReceiver : MessageReceiver {
@@ -121,14 +127,13 @@ internal class TaskReceiver(tasksDirectory: String,
         }
 
         val md5sum = dockerProcessor.getMd5Sum(rootFile)
-        val statusCode = 0
         this.onMessageProcessed("md5 sum of root file", md5sum)
 
         val onPublishFailureCallback = {
-            LOGGER.info("Publish failed: taskId = $taskId, status code = $statusCode, md5 sum: $md5sum")
+            LOGGER.info("Publish failed: taskId = $taskId, status code = ${StatusCode.SUCCESS.getCode()}, md5 sum: $md5sum")
         }
 
-        val data = getResultData(taskId, statusCode, md5sum)
+        val data = getResultData(taskId, StatusCode.SUCCESS.getCode(), md5sum)
         resultPublisher.publish(data, onPublishFailureCallback)
     }
 }

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -49,10 +49,8 @@ class SubscriberArgs(parser: ArgParser) {
     )
 }
 
-enum class StatusCode(private val code: Int) {
-    SUCCESS(0), FAILURE(1);
-
-    fun getCode(): Int = code
+enum class StatusCode {
+    SUCCESS, FAILURE;
 }
 
 private val PROJECT_ID = ServiceOptions.getDefaultProjectId()
@@ -130,10 +128,10 @@ internal class TaskReceiver(tasksDirectory: String,
         this.onMessageProcessed("md5 sum of root file", md5sum)
 
         val onPublishFailureCallback = {
-            LOGGER.info("Publish failed: taskId = $taskId, status code = ${StatusCode.SUCCESS.getCode()}, md5 sum: $md5sum")
+            LOGGER.info("Publish failed: taskId = $taskId, status code: ${StatusCode.SUCCESS}, md5 sum: $md5sum")
         }
 
-        val data = getResultData(taskId, StatusCode.SUCCESS.getCode(), md5sum)
+        val data = getResultData(taskId, StatusCode.SUCCESS, md5sum)
         resultPublisher.publish(data, onPublishFailureCallback)
     }
 }

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -60,7 +60,7 @@ abstract class CompilerFleetMessageReceiver : MessageReceiver {
     abstract fun processMessage(message: PubsubMessage)
 }
 
-val taskReceiverLogger = Logger.getLogger(TaskReceiver::class.java.getName())
+private val taskReceiverLogger = Logger.getLogger("TaskReceiver")
 
 internal class TaskReceiver(tasksDirectory: String,
                             resultTopic: String,

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -23,13 +23,13 @@ import com.google.common.io.ByteStreams
 import com.google.pubsub.v1.PubsubMessage
 import com.google.pubsub.v1.SubscriptionName
 import com.xenomachina.argparser.ArgParser
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
-import java.util.logging.Logger
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
@@ -60,7 +60,7 @@ abstract class CompilerFleetMessageReceiver : MessageReceiver {
     abstract fun processMessage(message: PubsubMessage)
 }
 
-private val TASK_LOGGER = Logger.getLogger("TaskReceiver")
+private val LOGGER = LoggerFactory.getLogger("TaskReceiver")
 
 internal class TaskReceiver(tasksDirectory: String,
                             resultTopic: String,
@@ -124,8 +124,8 @@ internal class TaskReceiver(tasksDirectory: String,
         val statusCode = 0
         this.onMessageProcessed("md5 sum of root file", md5sum)
 
-        val onPublishFailureCallback= {
-            TASK_LOGGER.info("Publish failed: taskId = $taskId, status code = $statusCode, md5 sum: $md5sum")
+        val onPublishFailureCallback = {
+            LOGGER.info("Publish failed: taskId = $taskId, status code = $statusCode, md5 sum: $md5sum")
         }
 
         val data = getResultData(taskId, statusCode, md5sum)

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -128,7 +128,7 @@ internal class TaskReceiver(tasksDirectory: String,
         this.onMessageProcessed("md5 sum of root file", md5sum)
 
         val onPublishFailureCallback = {
-            
+            LOGGER.info("Publish failed: $taskId, code: ${StatusCode.FAILURE}, md5 sum: $md5sum")
         }
 
         val data = getResultData(taskId, StatusCode.SUCCESS, md5sum)

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -128,8 +128,12 @@ class TaskReceiver(tasksDirectory: String,
         val compiledPdf = dockerProcessor.compileRmdToPdf(rootFile)
         this.callback("Compiled pdf name: ", compiledPdf.name)
 
-        val data = getResultData(taskId, 0, FileUtils.readFileToByteArray(compiledPdf))
-        resultPublisher.publish(data)
+        val onPublishFailureCallback = {
+            LOGGER.info("Publish $taskId failed with code ${StatusCode.FAILURE}")
+        }
+
+        val data = getResultData(taskId, StatusCode.SUCCESS, FileUtils.readFileToByteArray(compiledPdf))
+        resultPublisher.publish(data, onPublishFailureCallback)
     }
 }
 

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -60,7 +60,7 @@ abstract class CompilerFleetMessageReceiver : MessageReceiver {
     abstract fun processMessage(message: PubsubMessage)
 }
 
-private val taskReceiverLogger = Logger.getLogger("TaskReceiver")
+private val TASK_LOGGER = Logger.getLogger("TaskReceiver")
 
 internal class TaskReceiver(tasksDirectory: String,
                             resultTopic: String,
@@ -125,7 +125,7 @@ internal class TaskReceiver(tasksDirectory: String,
         this.onMessageProcessed("md5 sum of root file", md5sum)
 
         val onPublishFailureCallback= {
-            taskReceiverLogger.info("Publish failed: taskId = $taskId, status code = $statusCode, md5 sum: $md5sum")
+            TASK_LOGGER.info("Publish failed: taskId = $taskId, status code = $statusCode, md5 sum: $md5sum")
         }
 
         val data = getResultData(taskId, statusCode, md5sum)

--- a/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
+++ b/src/main/kotlin/com/bardsoftware/backend/fleet/rmarkdown/Subscriber.kt
@@ -128,7 +128,7 @@ internal class TaskReceiver(tasksDirectory: String,
         this.onMessageProcessed("md5 sum of root file", md5sum)
 
         val onPublishFailureCallback = {
-            LOGGER.info("Publish failed: taskId = $taskId, status code: ${StatusCode.SUCCESS}, md5 sum: $md5sum")
+            
         }
 
         val data = getResultData(taskId, StatusCode.SUCCESS, md5sum)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
At the moment, I've added only logging.
If there is a need to resend the message, I can also do that.

Do we need slf4j or more complicated approach to logger?

Do I need to pass some kind of callback to `TaskReceiver` for external failure processing?
In that case, I just don't know, what useful that thing can do besides logging.
Logging is the thing, that I'm already doing for processing.